### PR TITLE
Slight improvements.

### DIFF
--- a/Sources/Bitcoin/BitcoinPublicKey.swift
+++ b/Sources/Bitcoin/BitcoinPublicKey.swift
@@ -9,16 +9,14 @@ import Foundation
 public final class BitcoinPublicKey: PublicKey {
     /// Validates that raw data is a valid public key.
     static public func isValid(data: Data) -> Bool {
-        if data.isEmpty {
+        switch data.first {
+        case 2, 3:
+            return data.count == 33
+        case 4, 6, 7:
+            return data.count == 65
+        default:
             return false
         }
-        if data.first == 2 || data.first == 3 {
-            return data.count == 33
-        }
-        if data.first == 4 || data.first == 6 || data.first == 7 {
-            return data.count == 65
-        }
-        return false
     }
 
     /// Coin this key is for.

--- a/Sources/Data+Hex.swift
+++ b/Sources/Data+Hex.swift
@@ -37,25 +37,13 @@ extension Data {
 
     /// Converts an ASCII byte to a hex value.
     private static func value(of nibble: UInt8) -> UInt8? {
-        switch nibble {
-        case UInt8(ascii: "0") ... UInt8(ascii: "9"):
-            return nibble - UInt8(ascii: "0")
-        case UInt8(ascii: "a") ... UInt8(ascii: "f"):
-            return 10 + nibble - UInt8(ascii: "a")
-        case UInt8(ascii: "A") ... UInt8(ascii: "F"):
-            return 10 + nibble - UInt8(ascii: "A")
-        default:
-            return nil
-        }
+        guard let letter = String(bytes: [nibble], encoding: .ascii) else { return nil }
+        return UInt8(letter, radix: 16)
     }
 
     /// Returns the hex string representation of the data.
     public var hexString: String {
-        var string = ""
-        for byte in self {
-            string.append(String(format: "%02x", byte))
-        }
-        return string
+        return map({ String(format: "%02x", $0) }).joined()
     }
 }
 

--- a/Sources/Ethereum/Solidity/Function.swift
+++ b/Sources/Ethereum/Solidity/Function.swift
@@ -30,14 +30,7 @@ public struct Function: Equatable, CustomStringConvertible {
 
     /// Function signature
     public var description: String {
-        var string = "\(name)("
-        for param in parameters {
-            string += param.description + ","
-        }
-        if string.hasSuffix(",") {
-            string.removeLast()
-        }
-        string += ")"
-        return string
+        let descriptions = parameters.map({ $0.description }).joined(separator: ",")
+        return "\(name)(\(descriptions))"
     }
 }


### PR DESCRIPTION
This PR provides slight improvement/shortening to a few places.

`BitcoinPublicKey.swift`
- The idea is to use `switch` for `data.first`. Multiple comparings can be put in a single case.
- `data.first == nil` equals `data.isEmpty` so both these cases can be put in `default` since we need to `return false` in case of being empty and in other unhandled cases as well.

`Data+Hex.swift`
- The idea is to let initializers decide whether to `return nil` or not. Firstly we need to be able to parse UInt8 to ASCII letter. Then this ASCII letter can either be HEX digit or not.
- Joining formatted strings requires less code.

`Function.swift`
- String concatenation with comma-separator can be done more elegant.