### PR TITLE
Fix bitcoin cash p2sh script

### DIFF
--- a/Sources/Bitcoin/BitcoinTransaction+Building.swift
+++ b/Sources/Bitcoin/BitcoinTransaction+Building.swift
@@ -11,9 +11,8 @@ enum BitcoinTransactionError: LocalizedError {
 }
 
 public extension BitcoinTransaction {
-    static func build(to: Address, amount: Int64, fee: Int64, changeAddress: Address, utxos: [BitcoinUnspentTransaction]) throws -> BitcoinTransaction {
+    static func build(to: Address, amount: Int64, fee: Int64, changeAddress: Address, utxos: [BitcoinUnspentTransaction], bitcoin: Bitcoin = Bitcoin()) throws -> BitcoinTransaction {
 
-        let bitcoin = Bitcoin()
         let totalAmount: Int64 = utxos.reduce(0) { $0 + $1.output.value }
         let change: Int64 = totalAmount - amount - fee
 
@@ -42,11 +41,6 @@ public extension Bitcoin {
                 return BitcoinScript.buildPayToPublicKeyHash(bitcoinAddress.data.dropFirst())
             } else if bitcoinAddress.data[0] == self.p2shPrefix {
                 // address starts with 3/M
-                guard supportSegwit else {
-                    // bch doesn't support segwit and we don't support multi sig in the app
-                    // google: bitcoin cash stuck segwit
-                    return nil
-                }
                 return BitcoinScript.buildPayToScriptHash(bitcoinAddress.data.dropFirst())
             }
         } else if let bech32Address = address as? BitcoinBech32Address {

--- a/Tests/BitcoinCash/BitconCashTests.swift
+++ b/Tests/BitcoinCash/BitconCashTests.swift
@@ -38,9 +38,10 @@ class BitcoinCashTests: XCTestCase {
         XCTAssertEqual(scriptPub.data.hexString, "76a9146cfa0e96c34fce09c0e4e671fcd43338c14812e588ac")
 
         let address2 = BitcoinCashAddress(string: "bitcoincash:pzclklsyx9f068hd00a0vene45akeyrg7vv0053uqf")!
+        let scriptPub2 = bc.buildScript(for: address2)!
         XCTAssertEqual(address2.toBitcoinAddress().description, "3Hv6oV8BYCoocW4eqZaEXsaR5tHhCxiMSk")
-        XCTAssertNil(bc.buildScript(for: address2))
-        XCTAssertNil(bc.buildScript(for: address2.toBitcoinAddress()))
+        XCTAssertEqual(scriptPub2.data.hexString, "a914b1fb7e043152fd1eed7bfaf66679ad3b6c9068f387")
+        XCTAssertEqual(scriptPub2.data, bc.buildScript(for: address2.toBitcoinAddress())?.data)
     }
 
     func testExtendedKeys() {


### PR DESCRIPTION
1. Remove segwit check for bch, because it's a kind of user error.
2. Remove hardcoded `bitcoin = Bitcoin()`