### PR TITLE
Add support for Testnet keys derivation for Bitcoin bases currencies

### DIFF
--- a/Sources/Bitcoin/Bitcoin.swift
+++ b/Sources/Bitcoin/Bitcoin.swift
@@ -10,6 +10,14 @@ import Foundation
 ///
 /// Bitcoin-based blockchains should inherit from this class.
 open class Bitcoin: Blockchain {
+
+    convenience public init(purpose: Purpose = .bip84, network: SLIP.Network) {
+        self.init(purpose: purpose)
+        self.network = network
+    }
+
+    open var network: SLIP.Network = .main
+
     /// SLIP-044 coin type.
     override open var coinType: SLIP.CoinType {
         return .bitcoin
@@ -38,22 +46,48 @@ open class Bitcoin: Blockchain {
     }
 
     /// Public key hash address prefix.
+    ///
+    /// - SeeAlso: https://en.bitcoin.it/wiki/List_of_address_prefixes
     open var p2pkhPrefix: UInt8 {
-        return 0x00
+        switch network {
+        case .main:
+            return 0x00
+        case .test:
+            return 0x6f
+        }
     }
 
     /// Private key prefix.
+    ///
+    /// - SeeAlso: https://en.bitcoin.it/wiki/List_of_address_prefixes
     open var privateKeyPrefix: UInt8 {
-        return 0x80
+        switch network {
+        case .main:
+            return 0x80
+        case .test:
+            return 0xef
+        }
     }
 
     /// Pay to script hash (P2SH) address prefix.
+    ///
+    /// - SeeAlso: https://en.bitcoin.it/wiki/List_of_address_prefixes
     open var p2shPrefix: UInt8 {
-        return 0x05
+        switch network {
+        case .main:
+            return 0x05
+        case .test:
+            return 0xc4
+        }
     }
 
     open var hrp: SLIP.HRP {
-        return .bitcoin
+        switch network {
+        case .main:
+            return .bitcoin
+        case .test:
+            return .bitcoinTest
+        }
     }
 
     open var supportSegwit: Bool {
@@ -113,5 +147,9 @@ open class Bitcoin: Blockchain {
 
     open func legacyAddress(data: Data) -> Address? {
         return BitcoinAddress(data: data)
+    }
+
+    override public func derivationPath(account: Int = 0, change: Int = 0, at index: Int) -> DerivationPath {
+        return DerivationPath(purpose: coinPurpose.rawValue, coinType: network == .main ? coinType.rawValue : network.rawValue, account: account, change: change, address: index)
     }
 }

--- a/Sources/Bitcoin/PrivateKey+Bitcoin.swift
+++ b/Sources/Bitcoin/PrivateKey+Bitcoin.swift
@@ -13,6 +13,9 @@ extension PrivateKey {
         Bitcoin().privateKeyPrefix,
         Litecoin().privateKeyPrefix,
         Dash().privateKeyPrefix,
+        Bitcoin(network: .test).privateKeyPrefix,
+        Litecoin(network: .test).privateKeyPrefix,
+        Dash(network: .test).privateKeyPrefix,
     ])
 
     public convenience init?(wif: String) {

--- a/Sources/Bitcoin/PublicKey+Bitcoin.swift
+++ b/Sources/Bitcoin/PublicKey+Bitcoin.swift
@@ -26,11 +26,11 @@ public extension PublicKey {
         return address
     }
 
-    public func cashAddress() -> BitcoinCashAddress {
+    public func cashAddress(hrp: SLIP.HRP = .bitcoincash) -> BitcoinCashAddress {
         // slightly different from WitnessProgram.bech32Data
         let payload = Data([BitcoinCashAddress.p2khVersion]) + bitcoinKeyHash
         let data = convertBits(payload, from: 8, to: 5)!
-        let address = BitcoinCashAddress(data: data, hrp: SLIP.HRP.bitcoincash.rawValue)!
+        let address = BitcoinCashAddress(data: data, hrp: hrp.rawValue)!
         return address
     }
 

--- a/Sources/BitcoinCash/BitcoinCash.swift
+++ b/Sources/BitcoinCash/BitcoinCash.swift
@@ -12,12 +12,22 @@ public class BitcoinCash: Bitcoin {
         super.init(purpose: purpose)
     }
 
+    convenience public init(purpose: Purpose = .bip44, network: SLIP.Network) {
+        self.init(purpose: purpose)
+        self.network = network
+    }
+    
     override public var coinType: SLIP.CoinType {
         return .bitcoincash
     }
 
     override public var hrp: SLIP.HRP {
-        return .bitcoincash
+        switch network {
+        case .main:
+            return .bitcoincash
+        case .test:
+            return .bitcoincashTest
+        }
     }
 
     override public var supportSegwit: Bool {
@@ -25,7 +35,7 @@ public class BitcoinCash: Bitcoin {
     }
 
     override public func address(for publicKey: PublicKey) -> Address {
-        return publicKey.compressed.cashAddress()
+        return publicKey.compressed.cashAddress(hrp: hrp)
     }
 
     override open func address(string: String) -> Address? {

--- a/Sources/BitcoinCash/BitcoinCashAddress.swift
+++ b/Sources/BitcoinCash/BitcoinCashAddress.swift
@@ -34,7 +34,7 @@ public struct BitcoinCashAddress: Address, Equatable {
     }
 
     public static func validate(hrp: String) -> Bool {
-        return SLIP.HRP.bitcoincash.rawValue == hrp
+        return SLIP.HRP.bitcoincash.rawValue == hrp || SLIP.HRP.bitcoincashTest.rawValue == hrp
     }
 
     public static func cashAddrDecode(string: String) -> (Data, String)? {

--- a/Sources/Blockchain.swift
+++ b/Sources/Blockchain.swift
@@ -54,13 +54,13 @@ open class Blockchain: Hashable {
     public var hashValue: Int {
         return coinType.hashValue
     }
+
+    public func derivationPath(account: Int = 0, change: Int = 0, at index: Int) -> DerivationPath {
+        return DerivationPath(purpose: coinPurpose.rawValue, coinType: coinType.rawValue, account: account, change: change, address: index)
+    }
 }
 
 public extension Blockchain {
-    func derivationPath(account: Int = 0, change: Int = 0, at index: Int) -> DerivationPath {
-        return DerivationPath(purpose: coinPurpose.rawValue, coinType: coinType.rawValue, account: account, change: change, address: index)
-    }
-
     func derive(from extendedPubkey: String, at path: DerivationPath) -> Address? {
         guard let xpubV = xpubVersion,
             let xprvV = xprvVersion else {

--- a/Sources/Dash/Dash.swift
+++ b/Sources/Dash/Dash.swift
@@ -11,16 +11,37 @@ public final class Dash: Bitcoin {
         return .dash
     }
 
+    /// Private key prefix.
+    ///
+    /// - SeeAlso: https://dash-docs.github.io/en/developer-guide#wallet-import-format-wif
     override public var privateKeyPrefix: UInt8 {
-        return 0xCC
+        switch network {
+        case .main:
+            return 0xCC
+        case .test:
+            return 0xEF
+        }
     }
 
+    /// Public key hash address prefix.
+    ///
+    /// - SeeAlso: https://dash-docs.github.io/en/developer-reference#address-conversion
     public override var p2pkhPrefix: UInt8 {
-        return 0x4C
+        switch network {
+        case .main:
+            return 0x4C
+        case .test:
+            return 0x8c
+        }
     }
 
     override public init(purpose: Purpose = .bip44) {
         super.init(purpose: purpose)
+    }
+
+    convenience public init(purpose: Purpose = .bip44, network: SLIP.Network) {
+        self.init(purpose: purpose)
+        self.network = network
     }
 
     public override func address(for publicKey: PublicKey) -> Address {

--- a/Sources/Litecoin/Litecoin.swift
+++ b/Sources/Litecoin/Litecoin.swift
@@ -15,19 +15,39 @@ public final class Litecoin: Bitcoin {
     }
 
     override public var privateKeyPrefix: UInt8 {
-        return 0xB0
+        switch network {
+        case .main:
+            return 0xB0
+        case .test:
+            return 0xef
+        }
     }
 
     override public var p2pkhPrefix: UInt8 {
-        return 0x30
+        switch network {
+        case .main:
+            return 0x30
+        case .test:
+            return 0x6f
+        }
     }
 
     override public var p2shPrefix: UInt8 {
-        return 0x32
+        switch network {
+        case .main:
+            return 0x32
+        case .test:
+            return 0x3a
+        }
     }
 
     override public var hrp: SLIP.HRP {
-        return .litecoin
+        switch network {
+        case .main:
+            return .litecoin
+        case .test:
+            return .litecoinTest
+        }
     }
 
     override public var xpubVersion: SLIP.HDVersion? {

--- a/Sources/SLIP.swift
+++ b/Sources/SLIP.swift
@@ -29,6 +29,14 @@ public struct SLIP {
         case eos = 194
     }
 
+    /// Network type for coins with distinguished testnet keys derivation
+    ///
+    /// - SeeAlso: https://github.com/satoshilabs/slips/blob/master/slip-0044.md
+    public enum Network: Int {
+        case main
+        case test = 1
+    }
+
     ///  Registered HD version bytes
     ///
     /// - SeeAlso: https://github.com/satoshilabs/slips/blob/master/slip-0132.md
@@ -53,14 +61,20 @@ public struct SLIP {
     /// - SeeAlso: https://github.com/satoshilabs/slips/blob/master/slip-0173.md
     public enum HRP: String {
         case bitcoin = "bc"
+        case bitcoinTest = "tb"
         case litecoin = "ltc"
+        case litecoinTest = "tltc"
         case bitcoincash = "bitcoincash"
+        case bitcoincashTest = "bchtest"
 
         static var allSet: Set<String> {
             return [
                 HRP.bitcoin.rawValue,
+                HRP.bitcoinTest.rawValue,
                 HRP.litecoin.rawValue,
+                HRP.litecoinTest.rawValue,
                 HRP.bitcoincash.rawValue,
+                HRP.bitcoincashTest.rawValue,
             ]
         }
     }

--- a/Sources/Tron/Tron.swift
+++ b/Sources/Tron/Tron.swift
@@ -10,8 +10,14 @@ public final class Tron: Bitcoin {
     override public var coinType: SLIP.CoinType {
         return .tron
     }
+    
     override public var p2shPrefix: UInt8 {
-        return 0x41
+        switch network {
+        case .main:
+            return 0x41
+        case .test:
+            return 0xa0
+        }
     }
 
     override public func address(for publicKey: PublicKey) -> Address {

--- a/Tests/Bitcoin/BitcoinTestnetAddressTests.swift
+++ b/Tests/Bitcoin/BitcoinTestnetAddressTests.swift
@@ -1,0 +1,36 @@
+// Copyright © 2017-2018 Trust.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+import XCTest
+import TrustCore
+
+class BitcoinTestnetAddressTests: XCTestCase {
+
+    func testFromPrivateKeyLegacyAddress() {
+        let privateKey = PrivateKey(wif: "5KagSjmhacRK8BKZn6RyJei4BZy5EVQcrAKdAmHib6TFKPPpjWK")!
+        let publicKey = privateKey.publicKey(compressed: true)
+        let address = Bitcoin(purpose: .bip44, network: .test).address(for: publicKey)
+
+        XCTAssertEqual(address.description, "n3U23CQWzBAray99u6kJSipLh2VUDmt73h")
+    }
+
+    func testFromPrivateKeyCompatibleAddress() {
+        let privateKey = PrivateKey(wif: "5KagSjmhacRK8BKZn6RyJei4BZy5EVQcrAKdAmHib6TFKPPpjWK")!
+        let publicKey = privateKey.publicKey(compressed: true)
+        let address = Bitcoin(purpose: .bip49, network: .test).address(for: publicKey)
+
+        XCTAssertEqual(address.description, "2N9WgrehPoVfL5yYCDy6LjEA2N1yUoXY9pw")
+    }
+
+    func testFromPrivateKeyBech32Address() {
+        let privateKey = PrivateKey(wif: "5KagSjmhacRK8BKZn6RyJei4BZy5EVQcrAKdAmHib6TFKPPpjWK")!
+        let publicKey = privateKey.publicKey(compressed: true)
+        let address = Bitcoin(purpose: .bip84, network: .test).address(for: publicKey)
+
+        XCTAssertEqual(address.description, "tb1q7rz22qnw6tssa2ccnle8t9j3zn5zyap7kqva52")
+    }
+
+}

--- a/Tests/BitcoinCash/BitconCashTests.swift
+++ b/Tests/BitcoinCash/BitconCashTests.swift
@@ -64,6 +64,16 @@ class BitcoinCashTests: XCTestCase {
         XCTAssertEqual(xpubAddr9.description, "bitcoincash:qqyqupaugd7mycyr87j899u02exc6t2tcg9frrqnve")
     }
 
+    func testDeriveTestnetAddressFromXPub() {
+        let xpub = "xpub6CEHLxCHR9sNtpcxtaTPLNxvnY9SQtbcFdov22riJ7jmhxmLFvXAoLbjHSzwXwNNuxC1jUP6tsHzFV9rhW9YKELfmR9pJaKFaM8C3zMPgjw"
+        let bc = BitcoinCash(network: .test)
+        let xpubAddr2 = bc.derive(from: xpub, at: bc.derivationPath(at: 2))!
+        let xpubAddr9 = bc.derive(from: xpub, at: bc.derivationPath(at: 9))!
+
+        XCTAssertEqual(xpubAddr2.description, "bchtest:qq4cm0hcc4trsj98v425f4ackdq7h92rsy7sxhf50c")
+        XCTAssertEqual(xpubAddr9.description, "bchtest:qqyqupaugd7mycyr87j899u02exc6t2tcgpm8yzyt9")
+    }
+
     func testSignTransaction() throws {
         // Transaction on Bitcoin Cash Mainnet
         // https://blockchair.com/bitcoin-cash/transaction/96ee20002b34e468f9d3c5ee54f6a8ddaa61c118889c4f35395c2cd93ba5bbb4

--- a/Tests/DashTests.swift
+++ b/Tests/DashTests.swift
@@ -35,4 +35,14 @@ class DashAddressTests: XCTestCase {
         XCTAssertEqual(xpubAddr2.description, "Xh4D3Mv6ikL5iR45bEsCtaR8Ub4jkRLpU2")
         XCTAssertEqual(xpubAddr9.description, "XvwNJsXVBpvAU92xPwU8phT6wKjJVaBMkk")
     }
+
+    func testDeriveTestnetFromXPub() {
+        let xpub = "xpub6DRhaBX1cn2rRtbpphQTSLYcR3ABXzQeEYoT44MjbwTanhw1ePtNcYTZNeHyrJMsMGTbig4iFMSvht7RviohzFxkpjURgHDThygLqbZ1tib"
+        let bc = Dash(network: .test)
+        let xpubAddr2 = bc.derive(from: xpub, at: bc.derivationPath(account: 0, change: 1, at: 2))!
+        let xpubAddr9 = bc.derive(from: xpub, at: bc.derivationPath(account: 0, change: 1, at: 9))!
+
+        XCTAssertEqual(xpubAddr2.description, "ySgp4JzYAHzA49ydA6BbvbqUksZ7GqFrLq")
+        XCTAssertEqual(xpubAddr9.description, "ygZyKpbvdNaEosxVxnnXrisTDcDg1JKybg")
+    }
 }

--- a/Tests/Litecoin/LitecoinTests.swift
+++ b/Tests/Litecoin/LitecoinTests.swift
@@ -27,6 +27,21 @@ class LitecoinTests: XCTestCase {
         XCTAssertEqual(LitecoinBech32Address(string: "ltc1qytnqzjknvv03jwfgrsmzt0ycmwqgl0asjnaxwu")!.description, bech32Address.description)
     }
 
+    func testTestnetAddress() {
+        let litcoin = Litecoin(network: .test)
+        let privateKey = PrivateKey(wif: "cUiCtmMEwdNLGC8QuAPffTPGP3KyosKG66uLaswXp25EfLrUBj8r")!
+        let publicKey = privateKey.publicKey(compressed: true)
+
+        let legacyAddress = litcoin.legacyAddress(for: publicKey)
+        XCTAssertEqual(LitecoinAddress(string: "mkRJSdGuixGcRktuJdmwwBgisEALAAedrg")!.description, legacyAddress.description)
+
+        let compatibleAddress = litcoin.compatibleAddress(for: publicKey)
+        XCTAssertEqual(LitecoinAddress(string: "QV6nL5qn9Tzqthkt9zVuurYVTpkixzBygG")!.description, compatibleAddress.description)
+
+        let bech32Address = litcoin.address(for: publicKey)
+        XCTAssertEqual(LitecoinBech32Address(string: "tltc1qxhr08gtdjcmzxtx538vvqnhnyptlzxgnkwv6t0")!.description, bech32Address.description)
+    }
+
     func testExtendedKeys() {
         let wallet = HDWallet(mnemonic: "ripple scissors kick mammal hire column oak again sun offer wealth tomorrow wagon turn fatal", passphrase: "TREZOR")
 

--- a/Tests/PurposeTests.swift
+++ b/Tests/PurposeTests.swift
@@ -16,6 +16,11 @@ class PurposeTests: XCTestCase {
         XCTAssertEqual(.bip84, Litecoin().coinPurpose)
         XCTAssertEqual(.bip44, Dash().coinPurpose)
 
+        XCTAssertEqual(.bip84, Bitcoin(network: .test).coinPurpose)
+        XCTAssertEqual(.bip44, BitcoinCash(network: .test).coinPurpose)
+        XCTAssertEqual(.bip84, Litecoin(network: .test).coinPurpose)
+        XCTAssertEqual(.bip44, Dash(network: .test).coinPurpose)
+
         XCTAssertEqual(.bip44, Ethereum().coinPurpose)
         XCTAssertEqual(.bip44, Wanchain().coinPurpose)
         XCTAssertEqual(.bip44, Vechain().coinPurpose)

--- a/Tests/Tron/TronAddressTests.swift
+++ b/Tests/Tron/TronAddressTests.swift
@@ -35,4 +35,12 @@ class TronAddressTests: XCTestCase {
 
         XCTAssertEqual(address.description, "TJRyWwFs9wTFGZg3JbrVriFbNfCug5tDeC")
     }
+
+    func testTestnetFromPrivateKey() {
+        let privateKey =  PrivateKey(data: Data(hexString: "2d8f68944bdbfbc0769542fba8fc2d2a3de67393334471624364c7006da2aa54")!)!
+        let publicKey = privateKey.publicKey(compressed: false )
+        let address = Tron(network: .test).address(for: publicKey)
+
+        XCTAssertEqual(address.description, "27XYH4FaEc5UUxjvGdTVmvd7LAagXDc3dXv")
+    }
 }

--- a/TrustCore.xcodeproj/project.pbxproj
+++ b/TrustCore.xcodeproj/project.pbxproj
@@ -133,6 +133,7 @@
 		BBC0729B2191341400A9B082 /* BitcoinUnspentSelectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBC072992191340C00A9B082 /* BitcoinUnspentSelectorTests.swift */; };
 		BBD1CF7C2150F5CE00B99329 /* BitcoinBech32Address.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBD1CF7B2150F5CE00B99329 /* BitcoinBech32Address.swift */; };
 		BBD1CF7E2151EA1700B99329 /* WitnessProgram.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBD1CF7D2151EA1700B99329 /* WitnessProgram.swift */; };
+		D9C7B79D21C7D2B900F72D65 /* BitcoinTestnetAddressTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9C7B79C21C7D2B900F72D65 /* BitcoinTestnetAddressTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -280,6 +281,7 @@
 		BBD1CF7D2151EA1700B99329 /* WitnessProgram.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WitnessProgram.swift; sourceTree = "<group>"; };
 		D2663E7275439A0F14129090 /* Pods-TrustCore-TrustCoreTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TrustCore-TrustCoreTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-TrustCore-TrustCoreTests/Pods-TrustCore-TrustCoreTests.debug.xcconfig"; sourceTree = "<group>"; };
 		D64B0D7FFB6053D483E3DE8D /* Pods-TrustCore.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TrustCore.release.xcconfig"; path = "Pods/Target Support Files/Pods-TrustCore/Pods-TrustCore.release.xcconfig"; sourceTree = "<group>"; };
+		D9C7B79C21C7D2B900F72D65 /* BitcoinTestnetAddressTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BitcoinTestnetAddressTests.swift; sourceTree = "<group>"; };
 		DA1EEB65EA0444554E8E20B2 /* Pods-TrustCore-TrustCoreTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TrustCore-TrustCoreTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-TrustCore-TrustCoreTests/Pods-TrustCore-TrustCoreTests.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -535,6 +537,7 @@
 				611204CD21096D1300C2A28A /* BitcoinTransactionTests.swift */,
 				612B85D7212BCBCB00F5BCF5 /* BitcoinSignerTests.swift */,
 				BB116821217034A2007C8DC9 /* BitcoinScriptTests.swift */,
+				D9C7B79C21C7D2B900F72D65 /* BitcoinTestnetAddressTests.swift */,
 			);
 			path = Bitcoin;
 			sourceTree = "<group>";
@@ -1032,6 +1035,7 @@
 				61A728EC20F48A580005045D /* HDWalletTests.swift in Sources */,
 				6167558A207C7A1500018DC8 /* ERC20EncoderTests.swift in Sources */,
 				293AB63A21A6780D00B7DE52 /* EthereumChecksumTests.swift in Sources */,
+				D9C7B79D21C7D2B900F72D65 /* BitcoinTestnetAddressTests.swift in Sources */,
 				611EFEC520F5BD8700A00E53 /* DerivationPathTests.swift in Sources */,
 				77F8D3B02141CBB900E80CD6 /* DashTests.swift in Sources */,
 				8B6CF659216F70DC00DDD488 /* TronTransactionSignerTest.swift in Sources */,


### PR DESCRIPTION
I would like to add Testnet support for the following coins:
* Bitcoin
* Bitcoin Cash
* Litecoin
* Dash
* Tron

It was requested in #65 but it will be useful for everyone who wants to test trust-core on the Testnet network.

**Why I added `init(network: SLIP.Network)` to `Bitcoin` rather than to `Blockchain`?** 
Because it's not necessary for ERC20 based Tokens. There are no differences in address generation for main and test net nodes.

**Why I added `SLIP.Network` as an additional enum, rather than adding it to `SLIP.CoinType`?**
Method `blockchain(coin: SLIP.CoinType) -> Blockchain` should map CoinType to Blockchain. But `CoinType.test` will be used by all Bitcoin-based coins, so it will be not possible to use it in the current convention.